### PR TITLE
Add Guzzle 7.x to allowed versions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "minimum-stability": "RC",
     "require": {
         "php": ">=5.6.0 <8.0",
-        "guzzlehttp/guzzle": "^6.3.0",
+        "guzzlehttp/guzzle": "^6.3.0|^7.0.0",
         "codeception/lib-innerbrowser": "^1.0",
         "codeception/codeception": "^4.0"
     },


### PR DESCRIPTION
Guzzle has gone to significant lengths to ensure the public API for version 7.x is largely compatible with 6.x, so a cursory review of the code suggests this should be the only change required to enable it.

Adding support for Guzzle 7.x adds support for its built-in PSR-18 compliance elsewhere in our applications and would be very helpful!

Closes #4