### PR TITLE
Code standards updated to PHP 7.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0]
+        php: [7.1, 7.2, 7.3, 7.4, 8.0]
 
     steps:
     - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -1,38 +1,40 @@
 {
-    "name":"codeception/module-phpbrowser",
-    "description":"Codeception module for testing web application over HTTP",
-    "keywords":["codeception", "http", "functional-testing"],
-    "homepage":"http://codeception.com/",
-    "type":"library",
-    "license":"MIT",
-    "authors":[
-        {
-            "name":"Michael Bodnarchuk"
-        },
-        {
-            "name":"Gintautas Miselis"
-        }
-    ],
-    "minimum-stability": "RC",
-    "require": {
-        "php": ">=5.6.0 <9.0",
-        "guzzlehttp/guzzle": "^6.3|^7.0",
-        "codeception/lib-innerbrowser": "^1.3",
-        "codeception/codeception": "*@dev"
-    },
-    "require-dev": {
-        "codeception/module-rest": "^1.0"
-    },
-    "conflict": {
-        "codeception/codeception": "<4.0"
-    },
-    "suggest": {
-        "codeception/phpbuiltinserver": "Start and stop PHP built-in web server for your tests"
-    },
-    "autoload":{
-        "classmap": ["src/"]
-    },
-    "config": {
-        "classmap-authoritative": true
-    }
+	"name": "codeception/module-phpbrowser",
+	"description": "Codeception module for testing web application over HTTP",
+	"keywords": [ "codeception", "http", "functional-testing" ],
+	"homepage": "https://codeception.com/",
+	"type": "library",
+	"license": "MIT",
+	"authors": [
+		{
+			"name": "Michael Bodnarchuk"
+		},
+		{
+			"name": "Gintautas Miselis"
+		}
+	],
+	"minimum-stability": "RC",
+	"require": {
+		"php": "^7.1 || ^8.0",
+		"guzzlehttp/guzzle": "^6.3|^7.0",
+		"codeception/lib-innerbrowser": "^1.3",
+		"codeception/codeception": "*@dev"
+	},
+	"require-dev": {
+		"codeception/module-rest": "^1.0"
+	},
+	"conflict": {
+		"codeception/codeception": "<4.0"
+	},
+	"suggest": {
+		"codeception/phpbuiltinserver": "Start and stop PHP built-in web server for your tests"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"config": {
+		"classmap-authoritative": true
+	}
 }

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,10 @@ A Codeception module for testing web application over HTTP.
 [![Total Downloads](https://poser.pugx.org/codeception/module-phpbrowser/downloads)](https://packagist.org/packages/codeception/module-phpbrowser)
 [![License](https://poser.pugx.org/codeception/module-phpbrowser/license)](/LICENSE)
 
+## Requirements
+
+* `PHP 7.1` or higher.
+
 ## Installation
 
 ```

--- a/src/Codeception/Module/PhpBrowser.php
+++ b/src/Codeception/Module/PhpBrowser.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Module;
 
 use Closure;
@@ -76,9 +79,14 @@ use GuzzleHttp\Client as GuzzleClient;
  */
 class PhpBrowser extends InnerBrowser implements Remote, MultiSession
 {
-
+    /**
+     * @var string[]
+     */
     protected $requiredFields = ['url'];
 
+    /**
+     * @var array
+     */
     protected $config = [
         'headers' => [],
         'verify' => false,
@@ -95,6 +103,9 @@ class PhpBrowser extends InnerBrowser implements Remote, MultiSession
         'cookies' => true,
     ];
 
+    /**
+     * @var string[]
+     */
     protected $guzzleConfigFields = [
         'auth',
         'proxy',
@@ -143,17 +154,17 @@ class PhpBrowser extends InnerBrowser implements Remote, MultiSession
      * @param $name
      * @param $value
      */
-    public function setHeader($name, $value)
+    public function setHeader($name, $value): void
     {
         $this->haveHttpHeader($name, $value);
     }
 
-    public function amHttpAuthenticated($username, $password)
+    public function amHttpAuthenticated($username, $password): void
     {
         $this->client->setAuth($username, $password);
     }
 
-    public function amOnUrl($url)
+    public function amOnUrl($url): void
     {
         $host = Uri::retrieveHost($url);
         $config = $this->config;
@@ -167,11 +178,12 @@ class PhpBrowser extends InnerBrowser implements Remote, MultiSession
         $this->amOnPage($page);
     }
 
-    public function amOnSubdomain($subdomain)
+    public function amOnSubdomain($subdomain): void
     {
         $url = $this->config['url'];
-        $url = preg_replace('~(https?://)(.*\.)(.*\.)~', "$1$3", $url); // removing current subdomain
-        $url = preg_replace('~(https?://)(.*)~', "$1$subdomain.$2", $url); // inserting new
+        $url = preg_replace('#(https?://)(.*\.)(.*\.)#', "$1$3", $url); // removing current subdomain
+        $url = preg_replace('#(https?://)(.*)#', sprintf('$1%s.$2', $subdomain), $url);
+         // inserting new
         $config = $this->config;
         $config['url'] = $url;
         $this->_reconfigure($config);
@@ -193,20 +205,17 @@ class PhpBrowser extends InnerBrowser implements Remote, MultiSession
      * $I->executeInGuzzle(function (\GuzzleHttp\Client $client) {
      *      $client->get('/get', ['query' => ['foo' => 'bar']]);
      * });
-     * ?>
      * ```
      *
      * It is not recommended to use this command on a regular basis.
      * If Codeception lacks important Guzzle Client methods, implement them and submit patches.
      *
-     * @param Closure $function
      * @return mixed
      */
     public function executeInGuzzle(Closure $function)
     {
         return $function($this->guzzle);
     }
-
 
     public function _getResponseCode()
     {

--- a/src/Codeception/Module/PhpBrowser.php
+++ b/src/Codeception/Module/PhpBrowser.php
@@ -150,11 +150,8 @@ class PhpBrowser extends InnerBrowser implements Remote, MultiSession
 
     /**
      * Alias to `haveHttpHeader`
-     *
-     * @param $name
-     * @param $value
      */
-    public function setHeader($name, $value): void
+    public function setHeader(string $name, string $value): void
     {
         $this->haveHttpHeader($name, $value);
     }

--- a/tests/unit/Codeception/Module/PhpBrowserRestTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserRestTest.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 use Codeception\Test\Unit;
 use Codeception\Stub;
 
-class PhpBrowserRestTest extends Unit
+final class PhpBrowserRestTest extends Unit
 {
     /**
      * @var \Codeception\Module\REST

--- a/tests/unit/Codeception/Module/PhpBrowserTest.php
+++ b/tests/unit/Codeception/Module/PhpBrowserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Codeception\Exception\TestRuntimeException;
 use Codeception\Stub;
 
@@ -10,7 +12,7 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\AssertionFailedError;
 
-class PhpBrowserTest extends TestsForBrowsers
+final class PhpBrowserTest extends TestsForBrowsers
 {
     /**
      * @var \Codeception\Module\PhpBrowser
@@ -405,7 +407,7 @@ class PhpBrowserTest extends TestsForBrowsers
         $this->module->seeResponseCodeIs(200);
         $this->module->dontSee('Unauthorized');
         $this->module->see("Welcome, davert");
-        $this->module->amHttpAuthenticated(null, null);
+        $this->module->amHttpAuthenticated('', '');
         $this->module->amOnPage('/auth');
         $this->module->seeResponseCodeIs(401);
         $this->module->amHttpAuthenticated('davert', '123456');

--- a/tests/unit/Codeception/Module/TestsForBrowsers.php
+++ b/tests/unit/Codeception/Module/TestsForBrowsers.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 require_once 'TestsForWeb.php';
 /**
  * Author: davert

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * Author: davert
  * Date: 13.01.12


### PR DESCRIPTION
- The minimum version of PHP is now 7.1
- Added strict types
- Added return types
- Added typehints
- Removed unnecessary qualifiers