### PR TITLE
Cast uri to string

### DIFF
--- a/src/Codeception/Lib/Connector/Guzzle.php
+++ b/src/Codeception/Lib/Connector/Guzzle.php
@@ -184,7 +184,7 @@ class Guzzle extends AbstractBrowser
             }
             // relative url
             if (!$this->getHistory()->isEmpty()) {
-                return Uri::mergeUrls($this->getHistory()->current()->getUri(), $uri);
+                return Uri::mergeUrls((string)$this->getHistory()->current()->getUri(), $uri);
             }
         }
         return Uri::mergeUrls($baseUri, $uri);


### PR DESCRIPTION
This casting was removed by modernization PR #12
It is necessary to fix Codeception 5 build.