### PR TITLE
Require lib-innerbrowser 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^7.4 | ^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.3",
-        "codeception/lib-innerbrowser": "^1.5 | *@dev",
+        "codeception/lib-innerbrowser": "^2.0 | *@dev",
         "codeception/codeception": "^4.0 | *@dev"
     },
     "require-dev": {


### PR DESCRIPTION
module-phpbrowser 2.0 is incompatible with lib-innerbrowser 1.0 because property types don't match

See https://github.com/Codeception/Codeception/issues/6293