### PR TITLE
Add restrictions for symfony/browser-kit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "ext-json": "*",
         "codeception/codeception": "*@dev",
         "codeception/lib-innerbrowser": "*@dev",
-        "guzzlehttp/guzzle": "^7.4"
+        "guzzlehttp/guzzle": "^7.4",
+        "symfony/browser-kit": "^5.4 || ^6.0"
     },
     "require-dev": {
         "ext-curl": "*",


### PR DESCRIPTION
Because symfony/browser-kit 4.4 is not supported

Signature of Guzzle::getAbsoluteUri is not compatible with BrowserKit\Client
https://github.com/Codeception/module-phpbrowser/blob/master/src/Codeception/Lib/Connector/Guzzle.php#L159