### PR TITLE
Update composer.json to require PHP ^8 instead of ^8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "homepage": "https://codeception.com/",
     "require": {
-        "php": "^8.0",
+        "php": "^8",
         "ext-json": "*",
         "codeception/codeception": "*@dev",
         "codeception/lib-innerbrowser": "*@dev",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "homepage": "https://codeception.com/",
     "require": {
-        "php": "^8",
+        "php": "^8.0|^8.1",
         "ext-json": "*",
         "codeception/codeception": "*@dev",
         "codeception/lib-innerbrowser": "*@dev",


### PR DESCRIPTION
Since "^8.0" does not match PHP 8.1.9, it would be better to use "^8" in the composer.json