### PR TITLE
Test against PHP 8.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.1, 8.2, 8.3]
+        php: [8.1, 8.2, 8.3, 8.4]
 
     steps:
     - name: Checkout code

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ A Codeception module for testing web application over HTTP.
 
 ## Requirements
 
-* `PHP 8.0` or higher.
+* `PHP 8.1` or higher.
 
 ## Installation
 

--- a/tests/unit.suite.yml
+++ b/tests/unit.suite.yml
@@ -1,5 +1,5 @@
 # Codeception Test Suite Configuration
 
 # suite for unit (internal) tests.
-error_level: "E_ALL | E_STRICT"
+error_level: "E_ALL"
 class_name: UnitTester


### PR DESCRIPTION
The `E_STRICT` constant is removed because it is deprecated in PHP 8.4: https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant