### PR TITLE
chore(ci): remove release job for unsupported php 8.1 + simplify ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [ 8.1, 8.2, 8.3, 8.4, 8.5 ]
+        php: [ 8.2, 8.3, 8.4, 8.5 ]
 
     steps:
       - name: Checkout code
@@ -20,10 +20,6 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: none
-          # this ini directive seems to be off by default in PHP 8.5
-          # see https://github.com/php/php-src/issues/20279
-          # enable it because codeception relies on it.
-          ini-values: register_argc_argv=1
 
       - name: Validate composer.json and composer.lock
         run: composer validate


### PR DESCRIPTION
I forgot to remove the release job for PHP 8.1 in https://github.com/Codeception/module-phpbrowser/pull/48